### PR TITLE
Anti9uA / '심규보 - 2021/11/12 ) 카메라 통째로 수정'

### DIFF
--- a/Assets/FX/prefab/FX_Atler_Smoke.prefab
+++ b/Assets/FX/prefab/FX_Atler_Smoke.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8932038763434909818}
-  m_LocalRotation: {x: -0.04881079, y: 0.07349815, z: -0.21106482, w: 0.973482}
+  m_LocalRotation: {x: -0.048784457, y: 0.07351826, z: -0.21063662, w: 0.9735745}
   m_LocalPosition: {x: -181, y: 10, z: -39.1}
   m_LocalScale: {x: 1.2941, y: 1.2941, z: 1.2941}
   m_Children: []

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -4,7 +4,49 @@ using UnityEngine;
 
 public class CameraController : MonoBehaviour
 {
-    public Vector3 offset;
+    public float panSpeed = 20f;
+    public float panBorderThickness = 10f;
+
+    public float minY = 20f;
+    public float maxY = 120f;
+
+    public float scrollSpeed = 20f;
+
+    private void Update()
+    {
+        Vector3 pos = transform.position;
+
+        if (Input.GetKey("up") || Input.mousePosition.y >= Screen.height - panBorderThickness)
+        {
+            pos.z += panSpeed * Time.deltaTime;
+        }
+
+        if (Input.GetKey("down") || Input.mousePosition.y <= panBorderThickness)
+        {
+            pos.z -= panSpeed * Time.deltaTime;
+        }
+
+        if (Input.GetKey("right") || Input.mousePosition.x >= Screen.width - panBorderThickness)
+        {
+            pos.x += panSpeed * Time.deltaTime;
+        }
+
+        if (Input.GetKey("left") || Input.mousePosition.x <= panBorderThickness)
+        {
+            pos.x -= panSpeed * Time.deltaTime;
+        }
+
+        float scroll = Input.GetAxis("Mouse ScrollWheel");
+        pos.y -= scroll * scrollSpeed * 100f * Time.deltaTime;
+
+        pos.x = Mathf.Clamp(pos.x, -210, 175);
+        pos.y = Mathf.Clamp(pos.y, minY, maxY);
+        pos.z = Mathf.Clamp(pos.z, -200, 20);
+
+        transform.position = pos;
+    }
+}
+/*public Vector3 offset;
     public float zoomSpeed = 10.0f;
 
     private Transform player; // Player object
@@ -107,5 +149,4 @@ public class CameraController : MonoBehaviour
             transform.position = new Vector3(alter.position.x, transform.position.y, alter.position.z + transform.position.y / -nor);
             currentZ = transform.position.z;
         }
-    }
-}
+    }*/


### PR DESCRIPTION
- 이제 카메라가 범위 내로 나가지 않습니다.
- 기존 스크롤 기능과 마우스로 카메라를 움직일 수 있습니다.
- 또한 방향키 위 아래 우 왼 버튼으로 카메라를 움직일수 있습니다.
- 영웅과 알터로 돌아가는 스페이스와 알트 키는 정확한 위치가 확인되지 않아 일단 제외했습니다.
-