### PR TITLE
마우스 FX 좌표 틀어짐 문제 해결

### DIFF
--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -37,7 +37,6 @@ public class GameController : MonoBehaviour
 
         StartCoroutine(PlayTimer());
         StartCoroutine(WaveTimer());
-
     }
 
 
@@ -106,7 +105,9 @@ public class GameController : MonoBehaviour
             RaycastHit hit;
             Vector3 mPos;
 
-            if (Physics.Raycast(Camera.main.ScreenPointToRay(Input.mousePosition), out hit))
+            int layerMask = (1 << LayerMask.NameToLayer("Building")) + (1 << LayerMask.NameToLayer("Walkable"));
+
+            if (Physics.Raycast(Camera.main.ScreenPointToRay(Input.mousePosition), out hit, Mathf.Infinity,layerMask))
             {
                 mPos = hit.point; mPos.y = 0.3f;
                 fx_Move.transform.position = mPos;


### PR DESCRIPTION
'ㅁ')b

마우스를 클릭했을 때 발생하는 VFX의 좌표가 틀어지는 문제를 해결했습니다. 

이제 마우스 클릭 좌표를 알아내는 Ray가 LayerMask를 사용해 Building과 Walkable 레이어만 감지합니다.