### PR TITLE
자원지 위치,색 수정 및 워크샵 색 수정 & 블랙타워,워크샵 페이드아웃구현

### DIFF
--- a/Assets/Art/FX/prefab/Arrow_Medium.prefab
+++ b/Assets/Art/FX/prefab/Arrow_Medium.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6576817506870038233}
   - component: {fileID: 8236442372187352471}
   m_Layer: 0
-  m_Name: Blue
+  m_Name: Arrow_Medium
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -59,7 +59,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 1c587f160308c0a4ab867b64cfe1745a, type: 2}
+  - {fileID: 2100000, guid: 4029fff94e0149d49ae0ead3a0744d44, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Material/Arrow_Medium.mat
+++ b/Assets/Material/Arrow_Medium.mat
@@ -87,7 +87,7 @@ Material:
     - Vector1_28841e7d0ebd4071b8fa3060c8a958c7: 0
     - Vector1_a3dd8d74c0454d11969d1122cf037119: 0
     - Vector1_d1e57147e88a4ac8b6a9391eed06ff3d: 0
-    - _BumpScale: 1
+    - _BumpScale: 0
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
@@ -108,11 +108,11 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - Vector2_aefc51803626468d93e187720b33beb1: {r: 1, g: 0.15, b: 0, a: 0}
+    - Vector2_aefc51803626468d93e187720b33beb1: {r: 1, g: 0.1, b: 0, a: 0}
     - Vector2_d4d5b53cc35d40cb9d72579261570939: {r: 0, g: 0, b: 0, a: 0}
-    - _Color: {r: 0.013375282, g: 0, b: 1, a: 1}
-    - _Color0: {r: 0, g: 0.17391205, b: 1, a: 0}
-    - _Color1: {r: 0, g: 0.043581236, b: 0.2924528, a: 0}
+    - _Color: {r: 0, g: 0.96835494, b: 1, a: 1}
+    - _Color0: {r: 0, g: 1, b: 0.9098039, a: 0}
+    - _Color1: {r: 0, g: 0.14901961, b: 1, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _speed: {r: 1, g: 0.25, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Material/Arrow_Medium.mat.meta
+++ b/Assets/Material/Arrow_Medium.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1c587f160308c0a4ab867b64cfe1745a
+guid: 3004c7a968555ce48b868da52cf5e39b
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Material/Arrow_Small.mat
+++ b/Assets/Material/Arrow_Small.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Arrow_Small
-  m_Shader: {fileID: 4800000, guid: e17754d7559a70f4985b817f48d2fdfa, type: 3}
+  m_Shader: {fileID: 4800000, guid: 33af8a2df74556c4fac9d600bb464718, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 0
@@ -108,11 +108,11 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - Vector2_aefc51803626468d93e187720b33beb1: {r: 1, g: 0.1, b: 0, a: 0}
+    - Vector2_aefc51803626468d93e187720b33beb1: {r: 1, g: 0.15, b: 0, a: 0}
     - Vector2_d4d5b53cc35d40cb9d72579261570939: {r: 0, g: 0, b: 0, a: 0}
-    - _Color: {r: 0, g: 0.96835494, b: 1, a: 1}
-    - _Color0: {r: 0, g: 0.990309, b: 1, a: 0}
-    - _Color1: {r: 0, g: 0.1481996, b: 1, a: 0}
+    - _Color: {r: 0.013375282, g: 0, b: 1, a: 1}
+    - _Color0: {r: 1, g: 1, b: 1, a: 0}
+    - _Color1: {r: 1, g: 1, b: 1, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _speed: {r: 1, g: 0.25, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Material/Arrow_Small.mat.meta
+++ b/Assets/Material/Arrow_Small.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4029fff94e0149d49ae0ead3a0744d44
+guid: 1c587f160308c0a4ab867b64cfe1745a
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Material/Workshop_Medium.mat
+++ b/Assets/Material/Workshop_Medium.mat
@@ -119,7 +119,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0, g: 0.5176471, b: 1, a: 1}
-    - _Color: {r: 0.04513645, g: 0, b: 1, a: 1}
+    - _Color: {r: 0, g: 1, b: 0.9098039, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Material/Workshop_Small.mat
+++ b/Assets/Material/Workshop_Small.mat
@@ -106,7 +106,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 0.11372549, g: 0.6862745, b: 0.7490196, a: 1}
-    - _Color: {r: 0, g: 1, b: 0.9093275, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Prefabs/dark/Default Material_Flattened_Diffuse_Mat.mat
+++ b/Assets/Prefabs/dark/Default Material_Flattened_Diffuse_Mat.mat
@@ -74,6 +74,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 1, g: 0.33490568, b: 0.33490568, a: 0.56078434}
+    - _Color: {r: 1, g: 0.33490568, b: 0.33490568, a: 0.49803922}
     - _EmissionColor: {r: 0.2509804, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/EssenceSpot.cs
+++ b/Assets/Scripts/EssenceSpot.cs
@@ -8,7 +8,7 @@ public class EssenceSpot : MonoBehaviour
 
     [SerializeField] private int GetEssencePerOnce = 50;
     
-    private Material navy, blue, sky_blue;
+    private Material navy, white, sky_blue;
     private Material material;
 
 
@@ -16,8 +16,8 @@ public class EssenceSpot : MonoBehaviour
     {
         material = this.gameObject.GetComponent<Renderer>().material;
         navy = GetComponentInParent<EssenceManager>().materials[0];
-        blue = GetComponentInParent<EssenceManager>().materials[1];
-        sky_blue = GetComponentInParent<EssenceManager>().materials[2];
+        sky_blue = GetComponentInParent<EssenceManager>().materials[1];
+        white = GetComponentInParent<EssenceManager>().materials[2];
     }
 
 
@@ -54,17 +54,17 @@ public class EssenceSpot : MonoBehaviour
 
     void SetColor()
     {
-        if(RemainEssence >= 801)
+        if(RemainEssence >= 501)
         {
             gameObject.GetComponent<Renderer>().material = navy;
         }
-        else if(RemainEssence >= 401)
+        else if(RemainEssence >= 201)
         {
-            gameObject.GetComponent<Renderer>().material = blue;
+            gameObject.GetComponent<Renderer>().material = sky_blue;
         }
         else if(RemainEssence >= 1)
         {
-            gameObject.GetComponent<Renderer>().material = sky_blue;
+            gameObject.GetComponent<Renderer>().material = white;
         }
         else
         {

--- a/Assets/Scripts/Structure/WorkshopController.cs
+++ b/Assets/Scripts/Structure/WorkshopController.cs
@@ -34,6 +34,8 @@ public class WorkshopController : Building
     {
         currentRoofNum = GetRoofNum();
         roofRenderer = transform.GetChild(0).GetChild(0).GetComponent<MeshRenderer>();
+
+       // StartCoroutine("FadeOut"); //≥™¡ﬂø° fadeout Ω√¿€«“∂ß!
     }
 
 
@@ -199,4 +201,47 @@ public class WorkshopController : Building
         roofRenderer.materials = mats;
         beConstructed = false;
     }
+
+
+
+
+    IEnumerator FadeOut()
+    {
+        Debug.Log("2√ »ƒø° fadeout ");
+        yield return new WaitForSeconds(2f);
+        Debug.Log(" fadeout !! ");
+
+        Material[] materials = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials;
+
+
+        MeshRenderer mr = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>();
+        mr.materials[0].shader = Shader.Find("UI/Unlit/Transparent"); 
+        mr.materials[1].shader = Shader.Find("UI/Unlit/Transparent"); 
+        mr.materials[2].shader = Shader.Find("UI/Unlit/Transparent");
+
+        // materials[0] : øˆ≈©º• ¡ˆ∫ÿ , materials[1],[2] : øˆ≈©º• ±‚µ’
+        for (int i = 30; i >= 0; i--)
+        {
+
+
+            float f = i / 30.0f;
+            
+            for (int j = 0; j < 3; j++)
+            {
+                float c_r = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials[j].color.r;
+                float c_g = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials[j].color.g;
+                float c_b = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials[j].color.b;
+                float c_a = transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials[j].color.a;
+                Color c = new Color(c_r, c_g, c_b);
+                c.a = f;
+
+                transform.GetChild(0).gameObject.transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().materials[j].color = c;
+            }
+
+            yield return new WaitForSeconds(0.04f);
+        }
+     
+    }
+
+
 }

--- a/Assets/Scripts/TowerAttack.cs
+++ b/Assets/Scripts/TowerAttack.cs
@@ -9,6 +9,8 @@ public class TowerAttack : Stat
     public GameObject player;
     public ParticleSystem fx_blackTower;
     public ParticleSystem fx_hit;
+
+ 
     Stat _stat;
 
     private float AttackPerSeconds = 4f;
@@ -22,6 +24,8 @@ public class TowerAttack : Stat
         base.Init();
 
         bulletSpawnPosition = new Vector3(transform.position.x, transform.position.y + 18.98f, transform.position.z - 0.29f);
+
+       // StartCoroutine("FadeOut"); //fadeout할때 쓸 코드
     }
     public override void DeadSignal()
     {
@@ -34,6 +38,7 @@ public class TowerAttack : Stat
     void Start()
     {
         Init();
+   
     }
 
     private void Update()
@@ -47,6 +52,7 @@ public class TowerAttack : Stat
         }
         if((player.transform.position - transform.position).magnitude <=  ATTACK_RANGE)
         {
+            
             if (isAttack)
                 return;
             else
@@ -70,4 +76,50 @@ public class TowerAttack : Stat
         yield return new WaitForSeconds(AttackPerSeconds - fx_blackTower.main.startDelayMultiplier);
         isAttack = false;
     }
+
+    IEnumerator FadeOut()
+    {
+        Debug.Log("2초후에 fadeout ");
+        yield return new WaitForSeconds(2f);
+        Debug.Log(" fadeout !! ");
+
+        MeshRenderer mr_c1 = transform.GetChild(0).gameObject.GetComponent<MeshRenderer>();
+        mr_c1.material.shader = Shader.Find("UI/Unlit/Transparent");
+
+        MeshRenderer mr_c2 = transform.GetChild(1).gameObject.GetComponent<MeshRenderer>();
+        mr_c2.material.shader = Shader.Find("UI/Unlit/Transparent");
+
+        for (int i = 30; i >= 0; i--)
+            {
+         
+
+            float f = i /30.0f ;
+        
+                float c1_r = transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().material.color.r;
+                float c1_g = transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().material.color.g;
+                float c1_b = transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().material.color.b;
+                float c1_a = transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().material.color.a;
+            Color c1 = new Color(c1_r , c1_g , c1_b );
+            c1.a = f;
+     
+
+                float c2_r = transform.GetChild(1).gameObject.GetComponent<MeshRenderer>().material.color.r;
+                float c2_g = transform.GetChild(1).gameObject.GetComponent<MeshRenderer>().material.color.g;
+                float c2_b = transform.GetChild(1).gameObject.GetComponent<MeshRenderer>().material.color.b;
+                float c2_a = transform.GetChild(1).gameObject.GetComponent<MeshRenderer>().material.color.a;
+            Color c2 = new Color(c2_r , c2_g , c2_b );
+            c2.a = f ;
+           
+
+            
+            transform.GetChild(0).gameObject.GetComponent<MeshRenderer>().material.color = c1;
+            transform.GetChild(1).gameObject.GetComponent<MeshRenderer>().material.color = c2;
+            
+            yield return new WaitForSeconds(0.04f);
+            }
+        Destroy(transform.GetChild(0).gameObject.transform.GetChild(0).gameObject); //파티클 시스템 제거
+        Destroy(transform.GetChild(2).gameObject);
+    }
+    
+
 }


### PR DESCRIPTION
- map.unity 에서 자원지 small, medium, large 들의 위치를 맵에 맞게 수정하였습니다.
- 자원지와 워크샵의 색을 흰/하늘/남색 으로 구분하였습니다. ( 기존 : 하늘/파랑/남색)

- 블랙타워와 워크샵의 소멸구현을 위해 페이드아웃을 먼저 구현해놓았습니다.