### PR TITLE
알터 건설허용범위(도너츠모양) 추가 / 알터위치 및 허용범위radius전달 함수

### DIFF
--- a/Assets/Scripts/AlterController.cs
+++ b/Assets/Scripts/AlterController.cs
@@ -27,6 +27,10 @@ public class AlterController : Building, DamageService, HealthService
     {
         if(ObjectPooling.instance.Alter == null)
             ObjectPooling.instance.Alter_Setting(this.gameObject);
+
+        this.gameObject.transform.GetChild(3).gameObject.SetActive(false); //건설가능범위 비활성화
+        this.gameObject.transform.GetChild(4).gameObject.SetActive(false);//건설불가능범위 비활성화
+
     }
     // Update is called once per frame
     void Update()
@@ -144,4 +148,15 @@ public class AlterController : Building, DamageService, HealthService
         Instantiate(VFXAlterDestroy);
         Destroy(transform.GetChild(0).gameObject);
     }
+
+    public Vector3 getAlterPosition()
+    {
+        return this.gameObject.transform.position;
+    }
+
+    public float getAlterRange()
+    {
+        return this.gameObject.GetComponent<SphereCollider>().radius;
+    }
+
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -44,7 +44,8 @@ public class GameManager : MonoBehaviour
     }
 
     [SerializeField]
-    GameObject _alter;
+     GameObject _alter;
+
     public GameObject Alter
     {
         get
@@ -52,16 +53,36 @@ public class GameManager : MonoBehaviour
             if(_alter == null)
             {
                 _alter = GameObject.Find("alter");
+               // _alter = GameObject.FindGameObjectWithTag("alter");
             }
             return _alter;
         }
         set
-        {
-            _alter = value;
-            AlterIsChange.Invoke(_alter);
-        }
+        {     
+                _alter = value;
+                AlterIsChange.Invoke(_alter);
+       
+                return;
+        
+              
+         }
     }
     public Action<GameObject> AlterIsChange = null;
+
+
+    
+    public static Vector3 getAlterPosition() //Alter 위치 전달
+    {
+        return Instance.Alter.gameObject.transform.position;
+    }
+
+    public static float getAlterRadius() //건설가능범위 radius 전달
+    {
+        float radius = (Instance.Alter.gameObject.transform.GetChild(3).gameObject.transform.localScale.z)/2;
+        return radius;
+    }
+    
+
 
 
     static GameManager s_instance;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -56,3 +56,9 @@ TagManager:
   - name: Default
     uniqueID: 0
     locked: 0
+  - name: BuildRange
+    uniqueID: 4008467451
+    locked: 0
+  - name: NoBuildRange
+    uniqueID: 4146621473
+    locked: 0


### PR DESCRIPTION
1. 알터 건설허용범위(도너츠모양)을 추가하였습니다.

2. 알터위치 및 허용범위radius전달 함수를 GameManager에다가 넣어놓았습니다.
사용을 원할 시, 
GameManager.getAlterPosition() : 알터 위치 전달 ( Vector3 반환 )
GameManager.getAlterRadius() : 알터 건설가능범위 radius 전달 ( float 반환 )
이렇게 사용하시면 될것같습니다. 