### PR TITLE
알터위치 변경시 총알 위치변경 , 건설중일때 범위표시

### DIFF
--- a/Assets/Art/FX/prefab/FX_Atler_Smoke.prefab
+++ b/Assets/Art/FX/prefab/FX_Atler_Smoke.prefab
@@ -25,8 +25,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8932038763434909818}
-  m_LocalRotation: {x: -0.06565121, y: 0.08667127, z: 0.021954667, w: 0.99382895}
-  m_LocalPosition: {x: -181, y: 9.963865, z: -39.1}
+  m_LocalRotation: {x: -0.45765874, y: 0.08338143, z: 0.055055633, w: 0.8834959}
+  m_LocalPosition: {x: -181, y: 10.000074, z: -39.1}
   m_LocalScale: {x: 1.2941, y: 1.2941, z: 1.2941}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scripts/AlterAttack.cs
+++ b/Assets/Scripts/AlterAttack.cs
@@ -13,7 +13,7 @@ public class AlterAttack : Stat
 
     private float AttackPerSeconds = 4f;
 
-    private Vector3 bulletSpawnPosition;
+    private  Vector3 bulletSpawnPosition;
     bool isAttack = false;
 
     void Start()
@@ -109,5 +109,12 @@ public class AlterAttack : Stat
       
     }
 
-   
+    public void bulletSpawnNewSetting()
+    {
+        bulletSpawnPosition = new Vector3(transform.position.x, transform.position.y + 10f, transform.position.z);
+
+    }
+
+
+
 }

--- a/Assets/Scripts/Structure/Building11.cs
+++ b/Assets/Scripts/Structure/Building11.cs
@@ -8,6 +8,8 @@ public class Building11 : MonoBehaviour
     [SerializeField] private int timer = 10;
      public bool isTimerON = false;
     bool First = true;
+
+    private GameObject alter;
     public void Init()
     {
         switch (this.gameObject.name)
@@ -98,7 +100,12 @@ public class Building11 : MonoBehaviour
                 switch (objectName)
                 {
                     case "Alter":
-                        GameObject.Find("alter").transform.position = this.transform.position;
+                        alter = GameObject.Find("alter").gameObject;
+                        alter.transform.position = this.transform.position;
+
+                        AlterAttack alterAttack = alter.GetComponent<AlterAttack>();
+                        alterAttack.bulletSpawnNewSetting();
+
                         GameManager.Instance.AlterIsChange.Invoke(this.gameObject);
                         Destroy(this.gameObject);
                         break;

--- a/Assets/Scripts/Structure/BuildingManager.cs
+++ b/Assets/Scripts/Structure/BuildingManager.cs
@@ -16,6 +16,7 @@ public class BuildingManager : MonoBehaviour
     [SerializeField] private GameObject alter;
 
     private List<WhiteTowerAttack> whiteTowerList = new List<WhiteTowerAttack>();
+    private List<BuildingRange> buildingRangeList = new List<BuildingRange>();
 
     private GameObject go;
 
@@ -48,15 +49,20 @@ public class BuildingManager : MonoBehaviour
         {
             SetBuildPosition("Workshop", new Vector3(0, 0, 0));
         }
-        
-        if (Input.GetKeyDown(KeyCode.Z))
+       
+        if (Input.GetKeyDown(KeyCode.B))
         {
            BuildingRangeON(true);
         }
+        if (Input.GetKeyDown(KeyCode.N))
+        {
+            BuildingRangeON(false);
+        }
 
-    }
-    */
-    private void Start()
+
+    } */
+
+        private void Start()
     {
         build_alter.SetActive(false);
         build_whitetower.SetActive(false);
@@ -76,7 +82,9 @@ public class BuildingManager : MonoBehaviour
             case eBuilding.WhiteTower:
                 go = Instantiate(build_whitetower, pos, transform.rotation);
                 whiteTowerList.Add(go.transform.GetChild(1).gameObject.GetComponent<WhiteTowerAttack>());
+                buildingRangeList.Add(go.transform.GetChild(0).gameObject.GetComponent<BuildingRange>());
                 go.SetActive(true);
+
                 go.GetComponent<Building11>().Init();
 
                 break;
@@ -94,9 +102,9 @@ public class BuildingManager : MonoBehaviour
     public void BuildingRangeON(bool check) //건물들 rangeON
     {
         InterfaceRange interfaceRange;
-     
-            interfaceRange = altercontroller.GetComponent<InterfaceRange>();
-            interfaceRange.BuildingRangeON(check);
+
+        interfaceRange = altercontroller.GetComponent<InterfaceRange>();
+        interfaceRange.BuildingRangeON(check);
 
         for (int i = 0; i < whiteTowerList.Count; i++)
         {
@@ -110,20 +118,35 @@ public class BuildingManager : MonoBehaviour
                 whiteTowerList.RemoveAt(i); //whitetower 소멸되었을 경우
             }
         }
+
+
+        for (int i = 0; i < buildingRangeList.Count; i++)
+        {
+            if (buildingRangeList[i] != null)
+            {
+                interfaceRange = buildingRangeList[i].GetComponent<InterfaceRange>();
+                interfaceRange.BuildingRangeON(check);
+            }
+            else
+            {
+                buildingRangeList.RemoveAt(i); //buildingRange 소멸되었을 경우
+            }
+        }
+
     }
 
-    public  Vector3 GetAlterPosition() //Alter 위치 전달
+    public Vector3 GetAlterPosition() //Alter 위치 전달
     {
         return alter.gameObject.transform.position;
     }
 
-    public  float GetAlterBuildRadius() //알터 건설가능범위 radius 전달
+    public float GetAlterBuildRadius() //알터 건설가능범위 radius 전달
     {
         float radius = (alter.gameObject.transform.GetChild(2).gameObject.transform.localScale.x) / 2;
         return radius;
     }
 
-    public  float GetAlterNoBuildRadius() //알터 건설 불가능범위 radius 전달
+    public float GetAlterNoBuildRadius() //알터 건설 불가능범위 radius 전달
     {
         float radius = ((alter.gameObject.transform.GetChild(2).gameObject.transform.localScale.x) * (float)0.3) / 2;
         return radius;

--- a/Assets/Scripts/Structure/BuildingRange.cs
+++ b/Assets/Scripts/Structure/BuildingRange.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BuildingRange : MonoBehaviour, InterfaceRange
+{
+    private GameObject NoBuildRange;
+    private void Start()
+    {
+        NoBuildRange = transform.GetChild(0).gameObject;
+        NoBuildRange.SetActive(false);
+    }
+
+    public void BuildingRangeON(bool check)
+    {
+        NoBuildRange.SetActive(check);
+      
+    }
+}

--- a/Assets/Scripts/Structure/BuildingRange.cs.meta
+++ b/Assets/Scripts/Structure/BuildingRange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7894f1bfbce0044ca5c77c9d52dd299
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WhiteTowerAttack.cs
+++ b/Assets/Scripts/WhiteTowerAttack.cs
@@ -2,30 +2,30 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class WhiteTowerAttack : Stat,InterfaceRange
+public class WhiteTowerAttack : Stat, InterfaceRange
 {
 
     public ParticleSystem fx_whiteTower;
 
-   // Stat _stat;
+    // Stat _stat;
 
     private float AttackPerSeconds = 4f;
 
     private Vector3 bulletSpawnPosition;
-    private GameObject NoBuildRange ;
+    private GameObject NoBuildRange;
 
     bool isAttack = false;
-  
+
 
     public AudioSource SFXWhiteTowerDestroy;
     public AudioSource SFXWhiteTowerAttack;
 
- 
+
 
     protected override void Init()
     {
         base.Init();
-       // Debug.Log("base.HP : " + base.HP);
+        // Debug.Log("base.HP : " + base.HP);
         bulletSpawnPosition = new Vector3(transform.position.x, transform.position.y + 18.98f, transform.position.z - 0.29f);
         NoBuildRange = transform.GetChild(2).gameObject;
         NoBuildRange.SetActive(false);
@@ -139,7 +139,7 @@ public class WhiteTowerAttack : Stat,InterfaceRange
 
     }
 
-
+    /*
     public void WhiteTowerRangeON()
         {
         NoBuildRange.SetActive(true);
@@ -149,12 +149,15 @@ public class WhiteTowerAttack : Stat,InterfaceRange
     {
         NoBuildRange.SetActive(false);
     }
-
+    */
     public void BuildingRangeON(bool check)
     {
-        if (check)
-            NoBuildRange.SetActive(true);
-        else
-            NoBuildRange.SetActive(false);
+        if (NoBuildRange != null)
+        {
+            if (check)
+                NoBuildRange.SetActive(true);
+            else
+                NoBuildRange.SetActive(false);
+        }
     }
 }


### PR DESCRIPTION
1. 알터 건설하고 난 후, 위치가 변경되었을때 총알의 위치가 변경되지않았던 버그수정했습니다.
2. 건설중일때에도 건설불가범위를 시각화하여 건설할 수 있도록 수정하였습니다. 

건물 시각화 함수는 다음과 같이 있습니다.
<<BuildingManager 클래스>>
public void BuildingRangeON(bool check) //건물들 rangeON(true -> ON, false -> OFF)