### PR TITLE
현명은-2022/05/07) 알터,화이트타워 적 탐색 방식 교체/ 건물 건설 프리뷰 체크/ 알터위치변경 관련 클래스위치 변경…

### DIFF
--- a/Assets/Art/FX/prefab/FX_Atler_Smoke.prefab
+++ b/Assets/Art/FX/prefab/FX_Atler_Smoke.prefab
@@ -25,8 +25,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8932038763434909818}
-  m_LocalRotation: {x: 0.31435582, y: 0.06705303, z: 0.019249428, w: 0.94673854}
-  m_LocalPosition: {x: -126.5, y: 10.5, z: -39.5}
+  m_LocalRotation: {x: 0.001615406, y: 0.08872835, z: 0.0038926115, w: 0.996047}
+  m_LocalPosition: {x: -60.5, y: 10.5, z: -6.5}
   m_LocalScale: {x: 1.2941, y: 1.2941, z: 1.2941}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Prefabs/AlterBullet.prefab
+++ b/Assets/Prefabs/AlterBullet.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 830167911921947073}
   - component: {fileID: -7429529920191811638}
   - component: {fileID: 8399176652327327153}
-  - component: {fileID: -215397481522568577}
   - component: {fileID: 4987529720162287208}
   - component: {fileID: 2828935132261340792}
   m_Layer: 0
@@ -86,19 +85,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &-215397481522568577
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4987877886748572756}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 1
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &4987529720162287208
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -111,10 +97,10 @@ Rigidbody:
   m_Drag: 0
   m_AngularDrag: 0
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 2
+  m_CollisionDetection: 3
 --- !u!114 &2828935132261340792
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/BlackTowerBullet.prefab
+++ b/Assets/Prefabs/BlackTowerBullet.prefab
@@ -95,7 +95,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6618458519227913306}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
@@ -134,6 +134,7 @@ MonoBehaviour:
   fx_blackTowerPre:
   - {fileID: 7181758809996825297}
   - {fileID: 5385703142883666247}
+  SFXBlackTowerBullet: {fileID: 0}
 --- !u!82 &6154473936493838158
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/TowerBullet.prefab
+++ b/Assets/Prefabs/TowerBullet.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 1110599683775357695}
   - component: {fileID: 2826446632827359365}
   - component: {fileID: 309017012989154234}
-  - component: {fileID: 7162540831878058529}
   - component: {fileID: 6853206175738083950}
   - component: {fileID: 3177131756479620973}
   m_Layer: 0
@@ -118,19 +117,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &7162540831878058529
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6618458519227913306}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &6853206175738083950
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -143,7 +129,7 @@ Rigidbody:
   m_Drag: 0
   m_AngularDrag: 0
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0

--- a/Assets/Prefabs/WhiteTowerBullet.prefab
+++ b/Assets/Prefabs/WhiteTowerBullet.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4425515351427305969}
   - component: {fileID: 7615258507783901245}
   - component: {fileID: -3737108048412265157}
-  - component: {fileID: 9122199269919177345}
   - component: {fileID: 4519940782767269183}
   - component: {fileID: -2305766339726762854}
   m_Layer: 0
@@ -86,19 +85,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &9122199269919177345
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4307249530851287283}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &4519940782767269183
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -111,10 +97,10 @@ Rigidbody:
   m_Drag: 0
   m_AngularDrag: 0
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 64
-  m_CollisionDetection: 2
+  m_CollisionDetection: 3
 --- !u!114 &-2305766339726762854
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AlterAttack.cs
+++ b/Assets/Scripts/AlterAttack.cs
@@ -1,23 +1,30 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+
 
 public class AlterAttack : Stat
 {
 
     public ParticleSystem FX_Alter_Emit;
     public ParticleSystem FX_Alter_Smoke;
-  
+
     public AudioSource SFXAlterAttack;
     //
-
+    private GameController gameController;
 
     private float AttackPerSeconds = 4f;
 
-    private  Vector3 bulletSpawnPosition;
+    private Vector3 bulletSpawnPosition;
     bool isAttack = false;
+
+
+    private List<FreaksController> blackFreaks = new List<FreaksController>();
+
 
     void Start()
     {
+        gameController = FindObjectOfType<GameController>();
         Init();
     }
 
@@ -26,63 +33,36 @@ public class AlterAttack : Stat
     {
         base.Init();
         bulletSpawnPosition = new Vector3(transform.position.x, transform.position.y + 10f, transform.position.z);
-   
+        blackFreaks = gameController.GetAliveBlackFreaksList();
     }
 
-    private void OnTriggerEnter(Collider other)
+
+
+
+    void Update()
     {
 
 
-        if (other.transform.CompareTag("BlackFreaks"))
+        for (int i = 0; i < blackFreaks.Count; i++)
         {
-            if (isAttack)
-                return;
 
-            else
+
+            if ((blackFreaks[i].gameObject.transform.position - transform.position).magnitude < 30f)
             {
-             /*
-            if (!SFXAttackStart.isPlaying)
-            {
-                SFXAttackStart.Play();
-            }*/
-                StartCoroutine(FindInAttackRange(other.gameObject));
-                isAttack = true;
+                if (isAttack)
+                    return;
+                else
+                {
+                    StartCoroutine(FindInAttackRange(blackFreaks[i].gameObject));
+                    isAttack = true;
+                }
             }
 
         }
+
+
     }
 
-    private void OnTriggerStay(Collider other)
-    {
-        if (other.transform.CompareTag("BlackFreaks"))
-        {
-
-            if (isAttack)
-                return;
-
-            else
-            {
-          /*
-            if (!SFXAttackStart.isPlaying)
-            {
-                SFXAttackStart.Play();
-            }*/
-                StartCoroutine(FindInAttackRange(other.gameObject));
-                isAttack = true;
-            }
-        }
-    }
-
-
-    /*
-    private void OnTriggerExit(Collider other)
-    {
-        if (other.transform.CompareTag("BlackFreaks"))
-        {
-            StopAllCoroutines();
-        }
-    }
-    */
 
     IEnumerator FindInAttackRange(GameObject enemy)
     {
@@ -106,7 +86,7 @@ public class AlterAttack : Stat
         yield return new WaitForSeconds(AttackPerSeconds - FX_Alter_Emit.main.startDelayMultiplier);
 
         isAttack = false;
-      
+
     }
 
     public void bulletSpawnNewSetting()

--- a/Assets/Scripts/AlterBullet.cs
+++ b/Assets/Scripts/AlterBullet.cs
@@ -40,32 +40,13 @@ public class AlterBullet : MonoBehaviour
         enemyPos = new Vector3(enemy.transform.position.x, enemy.transform.position.y , enemy.transform.position.z);
 
 
-        switch (State)
+        if ((enemyPos - transform.position).magnitude < 10f)
         {
-            case 1:
-                fx_Alter[0].transform.LookAt(enemyPos);
-                transform.position += (enemyPos - transform.position).normalized * BulletSpeed * Time.deltaTime;
-                transform.rotation = Quaternion.identity;
-                break;
-            case 2:
-                transform.position += (enemyPos - transform.position).normalized * BulletSpeed * Time.deltaTime;
-                transform.rotation = Quaternion.identity;
-                break;
-            default:
-                break;
-        }
-    }
-
-    private void OnTriggerEnter(Collider other)
-    {
-        if (other.gameObject == enemy)
-        {
-
-            if (isCrushed == true || other == null)
+            if (isCrushed == true || enemy == null)
             {
                 return;
             }
-            GameManager.Damage.OnAttacked(_damage, other.GetComponent<Stat>());
+            GameManager.Damage.OnAttacked(_damage, enemy.GetComponent<Stat>());
             fx_Alter[0].Pause();
             fx_Alter[0].Play(false);
             fx_AlterPre[0].SetActive(false);
@@ -80,6 +61,21 @@ public class AlterBullet : MonoBehaviour
             isCrushed = true;
         }
 
+
+        switch (State)
+        {
+            case 1:
+                fx_Alter[0].transform.LookAt(enemyPos);
+                transform.position += (enemyPos - transform.position).normalized * BulletSpeed * Time.deltaTime;
+                transform.rotation = Quaternion.identity;
+                break;
+            case 2:
+                transform.position += (enemyPos - transform.position).normalized * BulletSpeed * Time.deltaTime;
+                transform.rotation = Quaternion.identity;
+                break;
+            default:
+                break;
+        }
     }
 
 

--- a/Assets/Scripts/AlterController.cs
+++ b/Assets/Scripts/AlterController.cs
@@ -50,6 +50,11 @@ public class AlterController : Building, DamageService, HealthService, Interface
             StartCoroutine("AlterDestroy");
       
         }*/
+
+        if (ConstructionPreviewManager.Instance.isPreviewMode)
+        {
+            BuildingRangeON(true);
+        }
     }
 
 
@@ -176,7 +181,7 @@ public class AlterController : Building, DamageService, HealthService, Interface
 
     public void BuildingRangeON(bool check)
     {
-        if(check)
+        if (check)
             BuildRange.SetActive(true);
         else
             BuildRange.SetActive(false);

--- a/Assets/Scripts/BulletPooling.cs
+++ b/Assets/Scripts/BulletPooling.cs
@@ -105,7 +105,6 @@ public class BulletPooling : MonoBehaviour
                 if (Instance.AlterBulletQueue.Count > 0)
                 {
                     var obj = instance.AlterBulletQueue.Dequeue();
-                    obj.transform.SetParent(null);
                     obj.gameObject.SetActive(true);
                     return obj;
                 }
@@ -118,7 +117,6 @@ public class BulletPooling : MonoBehaviour
                 if (Instance.WhiteBulletQueue.Count > 0)
                 {
                     var obj = instance.WhiteBulletQueue.Dequeue();
-                    obj.transform.SetParent(null);
                     obj.gameObject.SetActive(true);
                     return obj;
                 }
@@ -131,7 +129,6 @@ public class BulletPooling : MonoBehaviour
                 if (Instance.AlterBulletQueue.Count > 0)
                 {
                     var obj = instance.BlackBulletQueue.Dequeue();
-                    obj.transform.SetParent(null);
                     obj.gameObject.SetActive(true);
                     return obj;
                 }

--- a/Assets/Scripts/FreaksController.cs
+++ b/Assets/Scripts/FreaksController.cs
@@ -89,6 +89,7 @@ public class FreaksController : Stat
     {
         Debug.Log("AlterChanged");
         this.alter = go;
+        GoToAlter();
     }
     private void Update()
     {

--- a/Assets/Scripts/Structure/BuildingManager.cs
+++ b/Assets/Scripts/Structure/BuildingManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,6 +15,36 @@ public class BuildingManager : MonoBehaviour
     [Header("Alter")]
     [SerializeField] private AlterController altercontroller;
     [SerializeField] private GameObject alter;
+
+
+    public GameObject Alter
+    {
+        get
+        {
+            if (alter == null)
+            {
+                alter = GameObject.Find("alter");
+                // _alter = GameObject.FindGameObjectWithTag("alter");
+            }
+            return alter;
+        }
+        set
+        {
+            alter = value;
+            AlterIsChange.Invoke(alter);
+
+            return;
+
+
+        }
+    }
+
+
+
+
+    public Action<GameObject> AlterIsChange = null;
+
+
 
     private List<WhiteTowerAttack> whiteTowerList = new List<WhiteTowerAttack>();
     private List<BuildingRange> buildingRangeList = new List<BuildingRange>();
@@ -62,7 +93,7 @@ public class BuildingManager : MonoBehaviour
 
     } */
 
-        private void Start()
+    private void Start()
     {
         build_alter.SetActive(false);
         build_whitetower.SetActive(false);
@@ -151,6 +182,7 @@ public class BuildingManager : MonoBehaviour
         float radius = ((alter.gameObject.transform.GetChild(2).gameObject.transform.localScale.x) * (float)0.3) / 2;
         return radius;
     }
+
 
 
 }

--- a/Assets/Scripts/TowerBullet.cs
+++ b/Assets/Scripts/TowerBullet.cs
@@ -41,6 +41,33 @@ public class TowerBullet : MonoBehaviour
             return;
         playerPos = new Vector3(player.transform.position.x, player.transform.position.y + 1f, player.transform.position.z);
 
+        if ((playerPos - transform.position).magnitude < 10f)
+        {
+            if (isCrushed == true || player == null)
+            {
+                return;
+            }
+            SFXBlackTowerBullet.Play();
+
+            GameManager.Damage.OnAttacked(_damage, player.GetComponent<Stat>());
+            fx_blackTower[0].Pause();
+            fx_blackTower[0].Play(false);
+            fx_blackTowerPre[0].SetActive(false);
+            //Destroy(fx_blackTowerPre[0]);
+
+
+
+            fx_blackTowerPre[1].SetActive(true);
+            fx_blackTower[1] = fx_blackTowerPre[1].GetComponent<ParticleSystem>();
+            fx_blackTower[1].Play(true);
+
+            State = 2;
+            StartCoroutine(DeleteThis());
+            isCrushed = true;
+        }
+
+
+
         switch (State) 
         {
             case 1:
@@ -57,37 +84,7 @@ public class TowerBullet : MonoBehaviour
         }
     }
 
-
-    private void OnTriggerEnter(Collider other)
-    {
-        if (other.gameObject == player)
-        {
-            if (isCrushed == true || other == null)
-            {
-                return;
-            }
-
-     
-            SFXBlackTowerBullet.Play();
-
-            GameManager.Damage.OnAttacked(_damage, other.GetComponent<Stat>());
-            fx_blackTower[0].Pause();
-            fx_blackTower[0].Play(false);
-            fx_blackTowerPre[0].SetActive(false);
-            //Destroy(fx_blackTowerPre[0]);
-
-           
-
-            fx_blackTowerPre[1].SetActive(true);
-            fx_blackTower[1] = fx_blackTowerPre[1].GetComponent<ParticleSystem>();
-            fx_blackTower[1].Play(true);
-
-            State = 2;
-            StartCoroutine(DeleteThis());
-            isCrushed = true;
-        }
-    }
-
+  
     
 
     IEnumerator StartProjectile(float waitTime)

--- a/Assets/Scripts/WhiteTowerAttack.cs
+++ b/Assets/Scripts/WhiteTowerAttack.cs
@@ -14,6 +14,8 @@ public class WhiteTowerAttack : Stat, InterfaceRange
     private Vector3 bulletSpawnPosition;
     private GameObject NoBuildRange;
 
+    private GameController gameController;
+    private List<FreaksController> blackFreaks = new List<FreaksController>();
     bool isAttack = false;
 
 
@@ -21,10 +23,10 @@ public class WhiteTowerAttack : Stat, InterfaceRange
     public AudioSource SFXWhiteTowerAttack;
 
 
-
     protected override void Init()
     {
         base.Init();
+        blackFreaks = gameController.GetAliveBlackFreaksList();
         // Debug.Log("base.HP : " + base.HP);
         bulletSpawnPosition = new Vector3(transform.position.x, transform.position.y + 18.98f, transform.position.z - 0.29f);
         NoBuildRange = transform.GetChild(2).gameObject;
@@ -42,21 +44,48 @@ public class WhiteTowerAttack : Stat, InterfaceRange
 
     void Start()
     {
+        gameController = FindObjectOfType<GameController>();
         Init();
 
     }
 
     //소리 확인하기위한 update문
-    /*
+
     void Update()
     {
+        /*
         if (Input.GetKeyDown(KeyCode.A))
         {
             StartCoroutine("FadeOut");
+            
+        }*/
+
+        if (ConstructionPreviewManager.Instance.isPreviewMode)
+        {
+            BuildingRangeON(true);
+        }
+
+        for (int i = 0; i < blackFreaks.Count; i++)
+        {
+
+
+            if ((blackFreaks[i].gameObject.transform.position - transform.position).magnitude < 45f)
+            {
+                if (isAttack)
+                    return;
+                else
+                {
+                    StartCoroutine(FindInAttackRange(blackFreaks[i].gameObject));
+                    isAttack = true;
+                }
+            }
 
         }
+
+
+
     }
-    */
+    /*
     private void OnTriggerEnter(Collider other) //사거리범위 내에 블랙freaks가 들어올 경우
     {
         if (other.gameObject.CompareTag("BlackFreaks"))
@@ -87,7 +116,7 @@ public class WhiteTowerAttack : Stat, InterfaceRange
             }
         }
     }
-
+    */
 
     IEnumerator FindInAttackRange(GameObject blackFreaks)
     {

--- a/Assets/Scripts/WhiteTowerBullet.cs
+++ b/Assets/Scripts/WhiteTowerBullet.cs
@@ -33,7 +33,29 @@ public class WhiteTowerBullet : MonoBehaviour
         if (BlackFreaks == null)
             return;
         blackFreaksPos = new Vector3(BlackFreaks.transform.position.x, BlackFreaks.transform.position.y +1f , BlackFreaks.transform.position.z);
-      
+
+
+        if ((blackFreaksPos - transform.position).magnitude < 10f)
+        {
+            if (isCrushed == true || BlackFreaks == null)
+            {
+                return;
+            }
+            GameManager.Damage.OnAttacked(_damage, BlackFreaks.GetComponent<Stat>());
+            fx_whiteTower[0].Pause();
+            fx_whiteTower[0].Play(false);
+            fx_whiteTowerPre[0].SetActive(false);
+
+
+            fx_whiteTowerPre[1].SetActive(true);
+            fx_whiteTower[1] = fx_whiteTowerPre[1].GetComponent<ParticleSystem>();
+            fx_whiteTower[1].Play(true);
+
+            State = 2;
+            StartCoroutine(DeleteThis());
+            isCrushed = true;
+        }
+
 
         switch (State)
         {
@@ -51,33 +73,7 @@ public class WhiteTowerBullet : MonoBehaviour
         }       
     }
 
-
-    private void OnTriggerEnter(Collider other)
-    {
-        
-        if (other.gameObject == BlackFreaks)
-        {
-          
-            if (isCrushed == true || other == null)
-            {
-                return;
-            }
-            GameManager.Damage.OnAttacked(_damage, other.GetComponent<Stat>());
-            fx_whiteTower[0].Pause();
-            fx_whiteTower[0].Play(false);
-            fx_whiteTowerPre[0].SetActive(false);
   
-
-            fx_whiteTowerPre[1].SetActive(true);
-            fx_whiteTower[1] = fx_whiteTowerPre[1].GetComponent<ParticleSystem>();
-            fx_whiteTower[1].Play(true);
-
-            State = 2;
-            StartCoroutine(DeleteThis());
-            isCrushed = true;
-        }
-    }
-
 
     IEnumerator StartProjectile(float waitTime)
     {


### PR DESCRIPTION
…/ 불릿트리거체크

1. 알터,화이트타워 적 탐색 방식 교체
수용님이 캡쳐해주신 방법(black Freaks 리스트 및 magnitude) 그대로 사용하였습니다.

2. 건물 건설 프리뷰 체크
알터와 화이트타워가 매번 PreviewMode인지 체크를 하도록 하여 범위를 표시하도록 하였습니다.

3. 알터위치변경 관련 클래스위치 변경
GameManager에서 BuildingManager로 알터위치관련된 사항들 옮겼습니다.
혹시 몰라서 아직 GameManager에 남아는 있습니다만 이와 관련하여 참조 코드가 수정된다면 기존에 GameManager에 남아있는 코드들은 없애겠습니다.

4. 불릿트리거체크
기존에 체크되어있지않은 것들을 모두 트리거 체크하였습니다.

5. 자잘한 버그들 수정
물리연산을 쓰지않는 오브젝트의 경우(건물,총알) is Kinematic을 켜두었습니다.
총알들을 모두 magnitude를 사용하여 거리를 계산해 닿았는지를 판별하도록하였습니다.