### PR TITLE
Wise-eun / '현명은 - 2022/08/20) 알터관련 버그 수정 '

### DIFF
--- a/Assets/Scripts/WhiteFreaksController.cs
+++ b/Assets/Scripts/WhiteFreaksController.cs
@@ -97,7 +97,7 @@ public class WhiteFreaksController : Stat
         {
             IsMoving = false;
 
-            if (!(targetBefore.CompareTag("alter"))) //알터로 돌아가는게 아니라면(지으러 가는도중에 쥬금)
+            if (targetBefore.CompareTag("Friendly")) //알터로 돌아가는게 아니라면(지으러 가는도중에 쥬금)
             {
                 BuildingPooling.instance.ReturnObject(targetBuilding);
                 BuildingPooling.instance.ReturnObject(targetBefore);
@@ -109,6 +109,7 @@ public class WhiteFreaksController : Stat
                     connectEssence.SetActive(true);
                 }
             }
+           
             WhiteFreaksManager.Instance.ReturnWhiteFreaks();
             isFirst = false;
         }


### PR DESCRIPTION
워크샵이나 화이트타워 붕괴시, 화이트프릭스가 다시 알터로 돌아갈려고하면 알터가 사라지는 버그 수정함